### PR TITLE
use :create_additions to force creation of Ruby objects from JSON

### DIFF
--- a/test/cookie_test.rb
+++ b/test/cookie_test.rb
@@ -163,7 +163,7 @@ describe Cookie do
       end
       it "should automatically deserialize to a cookie" do
         json = "{\"json_class\":\"CookieJar::Cookie\",\"name\":\"foo\",\"value\":\"bar\",\"domain\":\"localhost.local\",\"path\":\"\\/\",\"created_at\":\"2009-09-11 12:51:03 -0600\",\"expiry\":\"2009-09-11 19:10:00 -0600\",\"secure\":true}" 
-        c = JSON.parse json
+        c = JSON.parse json, :create_additions => true
         c.should be_a Cookie
         CookieValidation.validate_cookie 'https://localhost/', c
       end

--- a/test/jar_test.rb
+++ b/test/jar_test.rb
@@ -223,7 +223,7 @@ describe Jar do
       
       it "should automatically deserialize to a jar" do
         json = "{\"json_class\":\"CookieJar::Jar\",\"cookies\":[{\"name\":\"foo\",\"value\":\"bar\",\"domain\":\"localhost.local\",\"path\":\"\\/\",\"created_at\":\"2009-09-11 12:51:03 -0600\",\"expiry\":\"2028-11-01 12:00:00 GMT\",\"secure\":true}]}" 
-        jar = JSON.parse json
+        jar = JSON.parse json, :create_additions => true
         jar.get_cookies('https://localhost/').should have(1).items  
       end
     end


### PR DESCRIPTION
Hi,

After CVE-2013-026, creation of Ruby Objects from JSON is deactivated by default. In order to authorize this, the option :create_additions has to be passed to JSON.parse.

This commit adds this to two places in tests, where needed.

Cheers,

Cédric
