### PR TITLE
'version' is a valid cookie parameter seen in the wild.

### DIFF
--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -320,6 +320,7 @@ module CookieJar
             args[:secure] = true
           when :httponly
             args[:http_only] = true
+          when :version
           else
             raise InvalidCookieError.new "Unknown cookie parameter '#{key}'"
           end

--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -321,6 +321,7 @@ module CookieJar
           when :httponly
             args[:http_only] = true
           when :version
+          when :"max-age"
           else
             raise InvalidCookieError.new "Unknown cookie parameter '#{key}'"
           end


### PR DESCRIPTION
The 'version' cookie parameter appears in the wild (for example, Amazon.com returns it with some cookies sometime, although I have not been able to narrow it down to a repeatable scenario), and seems to have existed at least at some time: http://www.ietf.org/rfc/rfc2109.txt