### PR TITLE
Validation fail

### DIFF
--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -247,6 +247,11 @@ module CookieJar
       end
 
       # The value for the Path attribute is not a prefix of the request-URI
+
+      # If the initial request path is empty then this will always fail
+      # so check if it is empty and if so then set it to /
+      request_path = "/" if request_path == ""
+
       unless request_path.start_with? cookie_path
         errors << "Path is not a prefix of the request uri path"
       end

--- a/lib/cookiejar/jar.rb
+++ b/lib/cookiejar/jar.rb
@@ -94,6 +94,10 @@ module CookieJar
         begin
           Cookie.from_set_cookie request_uri, value
         rescue InvalidCookieError
+            # This shouldn't just ignore errors, need some mechanism to report
+            # them back to the user
+            #puts "Invalid Cookie"
+            #puts e.inspect
         end
       end
 

--- a/lib/cookiejar/jar.rb
+++ b/lib/cookiejar/jar.rb
@@ -1,4 +1,5 @@
 require 'cookiejar/cookie'
+require "json"
 
 module CookieJar
   # A cookie store for client side usage.


### PR DESCRIPTION
If the initial request URL doesn't finish with a / , for example http://twitter.com then any cookies set by it are rejected as the request_path variable will be empty and so never match the cookie path.

I also think that as you are going to the effort of building up an errors array then you should somehow return it in some way so the developer can chose to view it to work out what is wrong with the cookies being set.