### PR TITLE
more updates including max-age, paths and validation failures

### DIFF
--- a/lib/cookiejar/cookie.rb
+++ b/lib/cookiejar/cookie.rb
@@ -186,7 +186,12 @@ module CookieJar
       # cookie path must start with the uri, it must not be a secure cookie
       # being sent over http, and it must not be a http_only cookie sent to
       # a script
-      path_match   = uri.path.start_with? @path
+	  if uri.path == ""
+	    path = "/"
+	  else
+	    path = uri.path
+	  end
+      path_match   = path.start_with? @path
       secure_match = !(@secure && uri.scheme == 'http')
       script_match = !(script && @http_only)
       expiry_match = !expired?

--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -319,6 +319,8 @@ module CookieJar
               raise unless $!.message == "time out of range"
               args[:expires_at] = Time.at(0x7FFFFFFF)
             end
+          when :"max-age"
+            args[:max_age] = keyvalue.to_i
           when *[:domain, :path]
             args[key] = keyvalue
           when :secure

--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -247,6 +247,11 @@ module CookieJar
       end
 
       # The value for the Path attribute is not a prefix of the request-URI
+
+      # If the initial request path is empty then this will always fail
+      # so check if it is empty and if so then set it to /
+      request_path = "/" if request_path == ""
+
       unless request_path.start_with? cookie_path
         errors << "Path is not a prefix of the request uri path"
       end

--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -147,6 +147,9 @@ module CookieJar
     #   requested uri
     def self.compute_search_domains request_uri
       uri = to_uri request_uri
+	  if not uri.is_a? URI::HTTP
+	  	return nil
+      end
       host = uri.host
       compute_search_domains_for_host host
     end

--- a/lib/cookiejar/jar.rb
+++ b/lib/cookiejar/jar.rb
@@ -94,6 +94,10 @@ module CookieJar
         begin
           Cookie.from_set_cookie request_uri, value
         rescue InvalidCookieError
+            # This shouldn't just ignore errors, need some mechanism to report
+            # them back to the user
+            #puts "Invalid Cookie"
+            #puts e.inspect
         end
       end
 

--- a/lib/cookiejar/jar.rb
+++ b/lib/cookiejar/jar.rb
@@ -1,4 +1,5 @@
 require 'cookiejar/cookie'
+require "json"
 
 module CookieJar
   # A cookie store for client side usage.

--- a/lib/cookiejar/jar.rb
+++ b/lib/cookiejar/jar.rb
@@ -214,7 +214,9 @@ module CookieJar
     # otherwise unordered.
     #
     # @param [String, URI] request_uri the address the HTTP request will be
-    #   sent to
+    #   sent to. This must be a full URI, i.e. must include the protocol,
+	#   if you pass digi.ninja it will fail to find the domain, you must pass
+	#   http://digi.ninja
     # @param [Hash] opts options controlling returned cookies
     # @option opts [Boolean] :script (false) Cookies marked HTTP-only will be ignored
     #   if true
@@ -223,11 +225,21 @@ module CookieJar
       uri = to_uri request_uri
       hosts = Cookie.compute_search_domains uri
 
+	  if hosts.nil?
+	  	return []
+      end
+
+	  if uri.path == ""
+	    path = "/"
+	  else
+	    path = uri.path
+	  end
+
       results = []
       hosts.each do |host|
         domain = find_domain host
-        domain.each do |path, cookies|
-          if uri.path.start_with? path
+        domain.each do |apath, cookies|
+          if path.start_with? apath
             results += cookies.values.select do |cookie|
               cookie.should_send? uri, opts[:script]
             end


### PR DESCRIPTION
I don't know if it is officially part of the basic version cookie standard but PHPsends the max-age field when it sets a cookie to expire, this PHP

```
setcookie ("notsession", "I am", time()+60*60*24*30, "", "", true, true);
```

sets the following cookie:

```
Set-Cookie: notsession=I+am; expires=Thu, 13-Nov-2014 12:12:44 GMT; Max-Age=2592000; secure; httponly
``` 