### PR TITLE
warning: mismatched indentations at 'end' with 'else'

### DIFF
--- a/lib/cookiejar/cookie.rb
+++ b/lib/cookiejar/cookie.rb
@@ -180,7 +180,7 @@ module CookieJar
                '/'
              else
                uri.path
-      end
+             end
       path_match   = path.start_with? @path
       secure_match = !(@secure && uri.scheme == 'http')
       script_match = !(script && @http_only)

--- a/lib/cookiejar/jar.rb
+++ b/lib/cookiejar/jar.rb
@@ -222,7 +222,7 @@ module CookieJar
                '/'
              else
                uri.path
-      end
+             end
 
       results = []
       hosts.each do |host|


### PR DESCRIPTION
Ruby 2.7 warns on these.