### PR TITLE
Add same_site attribute and tests

### DIFF
--- a/lib/cookiejar/cookie.rb
+++ b/lib/cookiejar/cookie.rb
@@ -47,6 +47,9 @@ module CookieJar
     # indicates specific ports on the HTTP server which should receive this
     # cookie if contacted.
     attr_reader :ports
+    # [String] SameSite cookie attribute value - see
+    # https://tools.ietf.org/html/draft-west-first-party-cookies-07
+    attr_reader :same_site
     # [Time] Time when this cookie was first evaluated and created.
     attr_reader :created_at
 
@@ -240,10 +243,12 @@ module CookieJar
     # Call {from_set_cookie} to create a new Cookie instance
     def initialize(args)
       @created_at, @name, @value, @domain, @path, @secure,
-      @http_only, @version, @comment, @comment_url, @discard, @ports \
+      @http_only, @version, @comment, @comment_url, @discard, @ports, \
+      @same_site \
       = args.values_at \
         :created_at, :name, :value, :domain, :path, :secure,
-        :http_only, :version, :comment, :comment_url, :discard, :ports
+        :http_only, :version, :comment, :comment_url, :discard, :ports,
+        :same_site
 
       @created_at ||= Time.now
       @expiry = args[:max_age] || args[:expires_at]

--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -322,7 +322,7 @@ module CookieJar
           when :httponly
             args[:http_only] = true
           when :samesite
-            args[:samesite] = keyvalue.downcase
+            args[:same_site] = keyvalue.downcase
           else
             fail InvalidCookieError, "Unknown cookie parameter '#{key}'"
           end

--- a/spec/cookie_spec.rb
+++ b/spec/cookie_spec.rb
@@ -43,6 +43,10 @@ describe Cookie do
       expect(cookie.name).to eq 'GALX'
       expect(cookie.secure).to be_truthy
     end
+    it 'should accept SameSite attribute' do
+      cookie = Cookie.from_set_cookie 'https://www.google.com/a/blah', 'GALX=RgmSftjnbPM;samesite=strict'
+      expect(cookie.same_site).to eq 'strict'
+    end
   end
   describe '#from_set_cookie2' do
     it 'should give back the input names and values' do

--- a/spec/cookie_validation_spec.rb
+++ b/spec/cookie_validation_spec.rb
@@ -74,6 +74,10 @@ describe CookieValidation do
       higher = Cookie.from_set_cookie 'http://foo.com/bar/baz/', 'foo=bar;path=/bar/'
       CookieValidation.validate_cookie('http://foo.com/bar/baz/', higher)
     end
+    it 'should accept SameSite attribute' do
+      cookie = Cookie.from_set_cookie 'http://127.0.0.1/', 'foo=bar;samesite=strict'
+      expect(CookieValidation.validate_cookie('http://127.0.0.1/', cookie)).to be_truthy
+    end
   end
   describe '#cookie_base_path' do
     it "should leave '/' alone" do


### PR DESCRIPTION
The commit https://github.com/dwaite/cookiejar/commit/adb79c0a14c2b347c5289e79379a1acfe34bf388 has as its message "add support for samesite cookie". It actually only makes the validator recognize the samesite attribute, but does not expose the value via the cookie object and does not add any tests.

This PR adds the same_site attribute (note that the instance variable name was changed to @same_site from @samesite to be consistent with http_only/httponly) and adds tests.