### PR TITLE
Travis: Drop unused sudo: false; use Rubinius 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 rvm:
  - 2.3.0
@@ -10,8 +9,14 @@ rvm:
  - 2.1.2
  - 2.0.0
  - jruby-19mode
- - rbx
+
 jdk:
- - oraclejdk8
+ - openjdk8
+
+matrix:
+  include:
+    - name: Rubinius
+      dist: trusty
+      rvm: rbx-4
 
 before_install: gem install bundler -v ">=1.9.3"


### PR DESCRIPTION
This PR updates Travis configuration to:

  - Drop the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
  - Use latest Rubinius
  - Pick a jdk supported by Travis

