### PR TITLE
Remove rspec-collection_matchers dependency.

### DIFF
--- a/cookiejar.gemspec
+++ b/cookiejar.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'rake', '>= 10.0', '< 13'
-  s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'yard',  '~> 0.9.20'
   s.add_development_dependency 'bundler', '>= 0.9.3'

--- a/spec/jar_spec.rb
+++ b/spec/jar_spec.rb
@@ -27,7 +27,7 @@ describe Jar do
       jar.set_cookie 'http://foo.com/', 'bar=baz'
       jar.set_cookie 'http://auth.foo.com/', 'foo=bar'
       jar.set_cookie 'http://auth.foo.com/', 'auth=135121...;domain=foo.com'
-      expect(jar.get_cookies('http://foo.com/')).to have(3).items
+      expect(jar.get_cookies('http://foo.com/').size).to eql(3)
     end
     it 'should let me read back a multiple cookies from 1 header' do
       jar = Jar.new
@@ -42,7 +42,7 @@ describe Jar do
       jar.set_cookie uri, 'c=bar;path=/a/b'
       jar.set_cookie uri, 'd=bar;path=/a/'
       cookies = jar.get_cookies(uri)
-      expect(cookies).to have(4).items
+      expect(cookies.size).to eql(4)
       expect(cookies[0].name).to eq 'b'
       expect(cookies[1].name).to eq 'a'
       expect(cookies[2].name).to eq 'c'
@@ -53,7 +53,7 @@ describe Jar do
       uri = 'http://localhost/'
       jar.set_cookie uri, 'foo=bar;expires=Wednesday, 09-Nov-99 23:12:40 GMT'
       cookies = jar.get_cookies(uri)
-      expect(cookies).to have(0).items
+      expect(cookies.size).to eql(0)
     end
   end
   describe '.get_cookie_headers' do
@@ -91,7 +91,7 @@ describe Jar do
       jar.set_cookie uri, 'c=bar;path=/a/b'
       jar.set_cookie uri, 'd=bar;path=/a/'
       jar.set_cookie 'http://localhost/', 'foo=bar'
-      expect(jar.to_a).to have(5).items
+      expect(jar.to_a.size).to eql(5)
     end
   end
   describe '.expire_cookies' do
@@ -103,9 +103,9 @@ describe Jar do
       jar.set_cookie uri, 'c=bar;path=/a/b'
       jar.set_cookie uri, 'd=bar;path=/a/'
       jar.set_cookie 'http://localhost/', 'foo=bar'
-      expect(jar.to_a).to have(5).items
+      expect(jar.to_a.size).to eql(5)
       jar.expire_cookies
-      expect(jar.to_a).to have(4).items
+      expect(jar.to_a.size).to eql(4)
     end
     it 'should let me expire all session cookies' do
       uri = 'http://foo.com/a/b/c/d'
@@ -115,9 +115,9 @@ describe Jar do
       jar.set_cookie uri, 'c=bar;path=/a/b'
       jar.set_cookie uri, 'd=bar;path=/a/'
       jar.set_cookie 'http://localhost/', 'foo=bar'
-      expect(jar.to_a).to have(5).items
+      expect(jar.to_a.size).to eql(5)
       jar.expire_cookies true
-      expect(jar.to_a).to have(1).items
+      expect(jar.to_a.size).to eql(1)
     end
   end
   describe '#set_cookies_from_headers' do
@@ -125,59 +125,59 @@ describe Jar do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'Set-Cookie' => 'foo=bar'
-      expect(cookies).to have(1).items
-      expect(jar.to_a).to have(1).items
+      expect(cookies.size).to eql(1)
+      expect(jar.to_a.size).to eql(1)
     end
     it 'should handle a set-cookie header' do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'set-cookie' => 'foo=bar'
-      expect(cookies).to have(1).items
-      expect(jar.to_a).to have(1).items
+      expect(cookies.size).to eql(1)
+      expect(jar.to_a.size).to eql(1)
     end
     it 'should handle multiple Set-Cookie headers' do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'Set-Cookie' => ['foo=bar', 'bar=baz']
-      expect(cookies).to have(2).items
-      expect(jar.to_a).to have(2).items
+      expect(cookies.size).to eql(2)
+      expect(jar.to_a.size).to eql(2)
     end
     it 'should handle a Set-Cookie2 header' do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'Set-Cookie2' => 'foo=bar;Version=1'
-      expect(cookies).to have(1).items
-      expect(jar.to_a).to have(1).items
+      expect(cookies.size).to eql(1)
+      expect(jar.to_a.size).to eql(1)
     end
     it 'should handle a set-cookie2 header' do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'set-cookie2' => 'foo=bar;Version=1'
-      expect(cookies).to have(1).items
-      expect(jar.to_a).to have(1).items
+      expect(cookies.size).to eql(1)
+      expect(jar.to_a.size).to eql(1)
     end
     it 'should handle multiple Set-Cookie2 headers' do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'Set-Cookie2' => ['foo=bar;Version=1', 'bar=baz;Version=1']
-      expect(cookies).to have(2).items
-      expect(jar.to_a).to have(2).items
+      expect(cookies.size).to eql(2)
+      expect(jar.to_a.size).to eql(2)
     end
     it 'should handle mixed distinct Set-Cookie and Set-Cookie2 headers' do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'Set-Cookie' => 'foo=bar',
                                              'Set-Cookie2' => 'bar=baz;Version=1'
-      expect(cookies).to have(2).items
-      expect(jar.to_a).to have(2).items
+      expect(cookies.size).to eql(2)
+      expect(jar.to_a.size).to eql(2)
     end
     it 'should handle overlapping Set-Cookie and Set-Cookie2 headers' do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'Set-Cookie' => ['foo=bar', 'bar=baz'],
                                              'Set-Cookie2' => 'foo=bar;Version=1'
-      expect(cookies).to have(2).items
-      expect(jar.to_a).to have(2).items
+      expect(cookies.size).to eql(2)
+      expect(jar.to_a.size).to eql(2)
       # and has the version 1 cookie
       expect(cookies.find do |cookie|
         cookie.name == 'foo'
@@ -187,8 +187,8 @@ describe Jar do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'Set-Cookie' => ['foo=bar', 'bar=baz;domain=.foo.com']
-      expect(cookies).to have(1).items
-      expect(jar.to_a).to have(1).items
+      expect(cookies.size).to eql(1)
+      expect(jar.to_a.size).to eql(1)
     end
   end
   begin
@@ -208,20 +208,20 @@ describe Jar do
         array = JSON.parse json
 
         jar = Jar.json_create array
-        expect(jar.get_cookies('https://localhost/')).to have(1).items
+        expect(jar.get_cookies('https://localhost/').size).to eql(1)
       end
       it 'should deserialize a JSON hash to a jar' do
         json = '{"cookies":[{"name":"foo","value":"bar","domain":"localhost.local","path":"\\/","created_at":"2009-09-11 12:51:03 -0600","expiry":"2028-11-01 12:00:00 GMT","secure":true}]}'
         hash = JSON.parse json
 
         jar = Jar.json_create hash
-        expect(jar.get_cookies('https://localhost/')).to have(1).items
+        expect(jar.get_cookies('https://localhost/').size).to eql(1)
       end
 
       it 'should automatically deserialize to a jar' do
         json = '{"json_class":"CookieJar::Jar","cookies":[{"name":"foo","value":"bar","domain":"localhost.local","path":"\\/","created_at":"2009-09-11 12:51:03 -0600","expiry":"2028-11-01 12:00:00 GMT","secure":true}]}'
         jar = JSON.parse json, create_additions: true
-        expect(jar.get_cookies('https://localhost/')).to have(1).items
+        expect(jar.get_cookies('https://localhost/').size).to eql(1)
       end
     end
   rescue LoadError

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'cookiejar'
 require 'rubygems'
 require 'rspec'
-require 'rspec/collection_matchers'
 require 'yaml'


### PR DESCRIPTION
This does not really really add to readability while one less dependency is beneficial.