### PR TITLE
Fix RSpec block syntax warnings

### DIFF
--- a/spec/cookie_spec.rb
+++ b/spec/cookie_spec.rb
@@ -65,10 +65,10 @@ describe Cookie do
       expect(cookie.secure).to be_truthy
     end
     it 'should fail on unquoted paths' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie2 'https://www.google.com/a/blah',
                                 'GALX=RgmSftjnbPM;Path=/a/;Secure;Version=1'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should accept quoted values' do
       cookie = Cookie.from_set_cookie2 'http://localhost/', 'foo="bar";Version=1'

--- a/spec/cookie_spec.rb
+++ b/spec/cookie_spec.rb
@@ -65,10 +65,10 @@ describe Cookie do
       expect(cookie.secure).to be_truthy
     end
     it 'should fail on unquoted paths' do
-      expect {
+      expect do
         Cookie.from_set_cookie2 'https://www.google.com/a/blah',
                                 'GALX=RgmSftjnbPM;Path=/a/;Secure;Version=1'
-      }.to raise_error InvalidCookieError
+      end.to raise_error InvalidCookieError
     end
     it 'should accept quoted values' do
       cookie = Cookie.from_set_cookie2 'http://localhost/', 'foo="bar";Version=1'

--- a/spec/cookie_validation_spec.rb
+++ b/spec/cookie_validation_spec.rb
@@ -5,46 +5,46 @@ describe CookieValidation do
   describe '#validate_cookie' do
     localaddr = 'http://localhost/foo/bar/'
     it 'should fail if version unset' do
-      expect(lambda do
+      expect {
         unversioned = Cookie.from_set_cookie localaddr, 'foo=bar'
         unversioned.instance_variable_set :@version, nil
         CookieValidation.validate_cookie localaddr, unversioned
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail if the path is more specific' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie localaddr, 'foo=bar;path=/foo/bar/baz'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail if the path is different than the request' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie localaddr, 'foo=bar;path=/baz/'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail if the domain has no dots' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://zero/', 'foo=bar;domain=zero'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for explicit localhost' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie localaddr, 'foo=bar;domain=localhost'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for mismatched domains' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://www.foo.com/', 'foo=bar;domain=bar.com'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for domains more than one level up' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://x.y.z.com/', 'foo=bar;domain=z.com'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for setting subdomain cookies' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://foo.com/', 'foo=bar;domain=auth.foo.com'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should handle a normal implicit internet cookie' do
       normal = Cookie.from_set_cookie 'http://foo.com/', 'foo=bar'

--- a/spec/cookie_validation_spec.rb
+++ b/spec/cookie_validation_spec.rb
@@ -5,46 +5,46 @@ describe CookieValidation do
   describe '#validate_cookie' do
     localaddr = 'http://localhost/foo/bar/'
     it 'should fail if version unset' do
-      expect {
+      expect do
         unversioned = Cookie.from_set_cookie localaddr, 'foo=bar'
         unversioned.instance_variable_set :@version, nil
         CookieValidation.validate_cookie localaddr, unversioned
-      }.to raise_error InvalidCookieError
+      end.to raise_error InvalidCookieError
     end
     it 'should fail if the path is more specific' do
-      expect {
+      expect do
         Cookie.from_set_cookie localaddr, 'foo=bar;path=/foo/bar/baz'
-      }.to raise_error InvalidCookieError
+      end.to raise_error InvalidCookieError
     end
     it 'should fail if the path is different than the request' do
-      expect {
+      expect do
         Cookie.from_set_cookie localaddr, 'foo=bar;path=/baz/'
-      }.to raise_error InvalidCookieError
+      end.to raise_error InvalidCookieError
     end
     it 'should fail if the domain has no dots' do
-      expect {
+      expect do
         Cookie.from_set_cookie 'http://zero/', 'foo=bar;domain=zero'
-      }.to raise_error InvalidCookieError
+      end.to raise_error InvalidCookieError
     end
     it 'should fail for explicit localhost' do
-      expect {
+      expect do
         Cookie.from_set_cookie localaddr, 'foo=bar;domain=localhost'
-      }.to raise_error InvalidCookieError
+      end.to raise_error InvalidCookieError
     end
     it 'should fail for mismatched domains' do
-      expect {
+      expect do
         Cookie.from_set_cookie 'http://www.foo.com/', 'foo=bar;domain=bar.com'
-      }.to raise_error InvalidCookieError
+      end.to raise_error InvalidCookieError
     end
     it 'should fail for domains more than one level up' do
-      expect {
+      expect do
         Cookie.from_set_cookie 'http://x.y.z.com/', 'foo=bar;domain=z.com'
-      }.to raise_error InvalidCookieError
+      end.to raise_error InvalidCookieError
     end
     it 'should fail for setting subdomain cookies' do
-      expect {
+      expect do
         Cookie.from_set_cookie 'http://foo.com/', 'foo=bar;domain=auth.foo.com'
-      }.to raise_error InvalidCookieError
+      end.to raise_error InvalidCookieError
     end
     it 'should handle a normal implicit internet cookie' do
       normal = Cookie.from_set_cookie 'http://foo.com/', 'foo=bar'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,4 @@ require 'rspec'
 require 'rspec/collection_matchers'
 require 'yaml'
 
-RSpec.configure do |config|
-  config.raise_errors_for_deprecations!
-end
+RSpec.configure(&:raise_errors_for_deprecations!)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,7 @@ require 'rubygems'
 require 'rspec'
 require 'rspec/collection_matchers'
 require 'yaml'
+
+RSpec.configure do |config|
+  config.raise_errors_for_deprecations!
+end


### PR DESCRIPTION
There were warnings on RSpec 3.11 about the block syntax

---

```
Deprecation Warnings:

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise CookieJar::InvalidCookieError` not `expect(value).to raise CookieJar::InvalidCookieError`
The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise CookieJar::InvalidCookieError` not `expect(value).to raise CookieJar::InvalidCookieError`
The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise CookieJar::InvalidCookieError` not `expect(value).to raise CookieJar::InvalidCookieError`
Too many similar deprecation messages reported, disregarding further reports. Pass `--deprecation-out` or set `config.deprecation_stream` to a file for full output.

If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

9 deprecation warnings total
```