### PR TITLE
Suppress deprecation warning for `Regexp.new` with 3rd argument

### DIFF
--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -45,7 +45,7 @@ module CookieJar
     HDN = /\A#{PATTERN::HOSTNAME}\Z/
     TOKEN = /\A#{PATTERN::TOKEN}\Z/
     PARAM1 = /\A(#{PATTERN::TOKEN})(?:=#{PATTERN::VALUE1})?\Z/
-    PARAM2 = Regexp.new "(#{PATTERN::TOKEN})(?:=(#{PATTERN::VALUE2}))?(?:\\Z|;)", '', 'n'
+    PARAM2 = Regexp.new "(#{PATTERN::TOKEN})(?:=(#{PATTERN::VALUE2}))?(?:\\Z|;)", Regexp::NOENCODING
     # TWO_DOT_DOMAINS = /\A\.(com|edu|net|mil|gov|int|org)\Z/
 
     # Converts the input object to a URI (if not already a URI)


### PR DESCRIPTION
Follow up https://github.com/ruby/ruby/pull/6976.

This PR suppresses the following deprecation warning.

```console
% ruby -v
ruby 3.2.1 (2023-02-08 revision 31819e82c8) [x86_64-darwin19]
% bundle exec rake
(snip)

/Users/koic/src/github.com/dwaite/cookiejar/lib/cookiejar/cookie_validation.rb:48: warning:
3rd argument to Regexp.new is deprecated and will be removed in Ruby 3.3; use 2nd argument instead
```